### PR TITLE
Fix nc unavailable in sandbox: bind-mount /etc/alternatives

### DIFF
--- a/sandbox/bin/opencode-sandbox
+++ b/sandbox/bin/opencode-sandbox
@@ -166,6 +166,11 @@ for netfile in /etc/hosts /etc/resolv.conf /etc/nsswitch.conf /etc/passwd /etc/g
     fi
 done
 
+# Alternatives system (needed for symlinks like /usr/bin/nc → /etc/alternatives/nmap)
+if [[ -d /etc/alternatives ]]; then
+    BINDS+=("--bind" "/etc/alternatives:/etc/alternatives:ro")
+fi
+
 # Current working directory (read-write)
 BINDS+=("--bind" "$(pwd):$(pwd):rw")
 


### PR DESCRIPTION
## Summary

- Bind-mount `/etc/alternatives` (read-only) into the sandbox container to fix broken symlinks for binaries using the RHEL alternatives system
- Root cause: `/usr/bin/nc → /etc/alternatives/nmap → /usr/bin/ncat` — middle link was dangling because `/etc/alternatives/` was not mounted

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)