### PR TITLE
Fix deploy.sh: chgrp sandbox launcher/SIF to ps-users, not ps-data

### DIFF
--- a/sandbox/deploy.sh
+++ b/sandbox/deploy.sh
@@ -45,7 +45,7 @@ echo "Deploying sandbox to ${DEPLOY_BASE} ..."
 if $DRY_RUN; then
     echo "[dry-run] Would copy: $SIF_FILE -> $DEPLOY_SIF"
     echo "[dry-run] Would copy: $LAUNCHER -> $DEPLOY_LAUNCHER"
-    echo "[dry-run] Would fix permissions (chgrp ps-data, chmod g+rX)"
+    echo "[dry-run] Would fix permissions (chgrp ps-users, chmod g+rX)"
     exit 0
 fi
 
@@ -58,9 +58,12 @@ echo "Copying launcher ..."
 cp "$LAUNCHER" "$DEPLOY_LAUNCHER"
 chmod +x "$DEPLOY_LAUNCHER"
 
-# Fix permissions for group access
+# Fix permissions for group access.
+# Group MUST be ps-users (~3744 employees), NOT ps-data (~60): these files are
+# not world-readable, so the group owner is how the broad employee population
+# gets access. Using ps-data here locks out everyone not in that small group.
 echo "Fixing permissions ..."
-chgrp ps-data "$DEPLOY_SIF" "$DEPLOY_LAUNCHER"
+chgrp ps-users "$DEPLOY_SIF" "$DEPLOY_LAUNCHER"
 chmod g+rX "$DEPLOY_SIF" "$DEPLOY_LAUNCHER"
 
 echo ""


### PR DESCRIPTION
## Incident

After deploying the `--no-sandbox` fix (PR #18), some users hit `permission denied` running `opencode-sandbox`.

**Root cause:** `deploy.sh` runs `chgrp ps-data` on the deployed launcher and SIF. Those files are **not world-readable**, so the group owner is how the broad employee population reaches them. `ps-data` has ~60 members; `ps-users` (the prior group) has ~3744. The deploy flipped `ps-users → ps-data`, dropping ~3684 users to `other` perms:

- `opencode-sandbox` → `other::--x` (execute, no read) → can't run a shell script
- `opencode-sandbox.sif` → `other::---` (no access) → sandbox can't read the SIF

## Fix

- `deploy.sh`: `chgrp ps-data` → `chgrp ps-users` (+ matching dry-run message), with a comment explaining why.
- The already-deployed files were restored to `ps-users` out of band, so users are unblocked now; this prevents the next deploy from reintroducing it.

## Verification

- Deployed launcher restored to `cwang31 ps-users -rwxrwx---`, SIF to `cwang31 ps-users -rwxr-x---`; `group::r-x` → all ps-users members get read+execute.
- `bash -n sandbox/deploy.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
